### PR TITLE
Add Droidcon Montreal 2016.

### DIFF
--- a/_conferences/droidcon-montreal-2016.md
+++ b/_conferences/droidcon-montreal-2016.md
@@ -1,0 +1,8 @@
+---
+name: "Droidcon"
+website: http://droidcon.ca/
+location: Montreal, Canada
+
+date_start: 2016-05-19
+date_end:   2016-05-20
+---


### PR DESCRIPTION
Adding for dates. Website not yet updated but will be same URL.
