### PR TITLE
Fix end date in iCalendar file

### DIFF
--- a/conferences.ics
+++ b/conferences.ics
@@ -14,7 +14,7 @@ LOCATION:{{ conference.location }}{% endif %}
 SUMMARY:{{ conference.name }}{% if conference.location %} ({{ conference.location }}){% endif %}
 CLASS:PUBLIC
 DTSTART;VALUE=DATE:{{ conference.date_start | date: "%Y%m%d" }}
-DTEND;VALUE=DATE:{{ conference.date_end | date: "%Y%m%d" }}
+DTEND;VALUE=DATE:{{ conference.date_end | date: "%s" | plus: 86400 | date: "%Y%m%d" }}
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%S" }}Z
 END:VEVENT
 {% endfor %}END:VCALENDAR


### PR DESCRIPTION
For all-day events the end date needs to be the day after the event.

Apparently many calendar applications still display what would mathematically be a 0 days/seconds event just fine. But multi-day events appeared one day short.
