### PR TITLE
Add CFP link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ date_end:   2015-10-30
 
 cfp_start: 2015-06-16  # Optional
 cfp_end:   2015-07-21  # Optional
+cfp_site: http://uk.droidcon.com/2015/lineup-2015/ # Optional, will default to website
 ---
 ```
 

--- a/_conferences/droidcon-sf-2015.md
+++ b/_conferences/droidcon-sf-2015.md
@@ -8,4 +8,5 @@ date_end:   2015-11-11
 
 cfp_start: 2015-08-28
 cfp_end:   2015-09-25
+cfp_site: https://droidcon-server.herokuapp.com
 ---

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ var today = new Date();
     <script>
       {% if conference.cfp_start %}
       if (today >= new Date('{{ conference.cfp_start | date: "%Y-%m-%d" }}') && today <= new Date('{{ conference.cfp_end | date: "%Y-%m-%d" }}')) {
-        document.write('<span class="label label-success">Call For Papers</span>');
+        document.write('<a href="{% if conference.cfp_site %}{{ conference.cfp_site }}{% else %}{{ conference.website }}{% endif %}"><span class="label label-success">Call For Papers</span></a>');
       }
       {% endif %}
       if (today >= new Date('{{ conference.date_start | date: "%Y-%m-%d" }}') && today <= new Date('{{ conference.date_end | date: "%Y-%m-%d" }}')) {


### PR DESCRIPTION
“Call for Papers” is always clickable and will default to the website when the CFP link is not given
#20
