### PR TITLE
Removed /2016 from the url

### DIFF
--- a/_conferences/droidcon-sf-2016.md
+++ b/_conferences/droidcon-sf-2016.md
@@ -1,6 +1,6 @@
 ---
 name: "Droidcon"
-website: http://sf.droidcon.com/2016
+website: http://sf.droidcon.com
 location: San Francisco, USA
 
 date_start: 2016-03-10


### PR DESCRIPTION
This resulted in a page that said "Page not found." Removing this now takes you to the index page.
