### PR TITLE
Update CfP deadline for Droidcon IT

### DIFF
--- a/_conferences/droidcon-it-2016.md
+++ b/_conferences/droidcon-it-2016.md
@@ -7,6 +7,6 @@ date_start: 2016-04-07
 date_end:   2016-04-08
 
 cfp_start: 2015-09-01  # Optional
-cfp_end:   2016-01-20  # Optional
+cfp_end:   2016-01-31  # Optional
 cfp_site: http://it.droidcon.com/2016/call-for-paper/ # Optional, will default to website
 ---


### PR DESCRIPTION
CfP deadline was moved to January 31.

http://it.droidcon.com/2016/call-for-papers/
