### PR TITLE
Add Droidcon NYC 2016 placeholder with dates

### DIFF
--- a/_conferences/droidcon-nyc-2016.md
+++ b/_conferences/droidcon-nyc-2016.md
@@ -1,0 +1,11 @@
+---
+name: "Droidcon"
+website: TBA
+location: New York City, USA
+
+date_start: 2016-09-29
+date_end:   2016-09-30
+
+cfp_start: TBA
+cfp_end:   TBA
+---

--- a/_conferences/droidcon-nyc-2016.md
+++ b/_conferences/droidcon-nyc-2016.md
@@ -1,6 +1,6 @@
 ---
 name: "Droidcon"
-website: TBA
+website: http://droidcon.nyc/
 location: New York City, USA
 
 date_start: 2016-09-29

--- a/_conferences/droidcon-nyc-2016.md
+++ b/_conferences/droidcon-nyc-2016.md
@@ -5,7 +5,4 @@ location: New York City, USA
 
 date_start: 2016-09-29
 date_end:   2016-09-30
-
-cfp_start: TBA
-cfp_end:   TBA
 ---


### PR DESCRIPTION
Droidcon NYC dates announced as September 29-30 this year.

No website or CFP details available yet.

See header image [here](https://twitter.com/droidconnyc) for confirmation of dates:

![](https://pbs.twimg.com/profile_banners/2383933981/1464104499/1500x500)
