### PR TITLE
Add CFP dates for Droidcon NYC 2016

### DIFF
--- a/_conferences/droidcon-nyc-2016.md
+++ b/_conferences/droidcon-nyc-2016.md
@@ -5,4 +5,7 @@ location: New York City, USA
 
 date_start: 2016-09-29
 date_end:   2016-09-30
+
+cfp_start: 2016-05-24
+cfp_end:   2016-07-15
 ---


### PR DESCRIPTION
> Speaker submissions are open now through July 15th. Please follow the speaker link from the info page: http://2016.droidcon.nyc
