### PR TITLE
Add GDG Devfest Hamburg 2016

### DIFF
--- a/_conferences/devfest-hamburg-2015.md
+++ b/_conferences/devfest-hamburg-2015.md
@@ -1,8 +1,0 @@
----
-name: "GDG DevFest"
-website: http://devfest.de/
-location: Hamburg, Germany
-
-date_start: 2015-11-05
-date_end:   2015-11-06
----

--- a/_conferences/devfest-hamburg-2016.md
+++ b/_conferences/devfest-hamburg-2016.md
@@ -1,0 +1,12 @@
+---
+name: "GDG Devfest"
+website: http://devfest.de/
+location: Hamburg, Germany
+
+date_start: 2016-10-14
+date_end:   2016-10-15
+
+cfp_start: 2016-07-28
+cfp_end:   2016-09-30
+cfp_site: https://goo.gl/forms/QHvE4MLIGFAOsG2w1
+---


### PR DESCRIPTION
- Add conference and cfp dates.
- Delete file for GDG Devfest Hamburg 2015.
