### PR TITLE
Fix date format of DevFest Hyderabad

### DIFF
--- a/_conferences/devfest-hyderabad-2016.md
+++ b/_conferences/devfest-hyderabad-2016.md
@@ -3,6 +3,6 @@ name: "GDG DevFest"
 website: http://devfest.gdghyd.org/
 location: Hyderabad, India
 
-date_start: 2016-10-1
-date_end:   2016-10-1
+date_start: 2016-10-01
+date_end:   2016-10-01
 ---


### PR DESCRIPTION
These invalid dates caused the page build to fail.
