### PR TITLE
Fix path to CSS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     <meta name="description" content="A community-curated list of conferences around the world for Android developers.">
 
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ "css/main.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
Currently we end up with

``` html
<link rel="stylesheet" href="/conferencescss/main.css">
```

which of course fails to load the CSS.
