### PR TITLE
FixTypo(?) codemobile: https -> http

### DIFF
--- a/_conferences/codemobile-2017.md
+++ b/_conferences/codemobile-2017.md
@@ -1,6 +1,6 @@
 ---
 name: "CodeMobile"
-website: https://www.codemobile.co.uk/
+website: http://www.codemobile.co.uk/
 location: Chester, UK
 
 date_start: 2017-04-17


### PR DESCRIPTION
The code mobile website is only available via `http`, not `https`.
