### PR TITLE
Date extended for CFP Droidcon Berlin 2017

### DIFF
--- a/_conferences/droidcon-berlin-2017.md
+++ b/_conferences/droidcon-berlin-2017.md
@@ -7,6 +7,6 @@ date_start: 2017-09-03
 date_end:   2017-09-05
 
 cfp_start: 2017-04-06
-cfp_end:   2017-05-14
+cfp_end:   2017-06-06
 cfp_site:  https://droidcon.de/en/berlin/17/call-papers
 ---


### PR DESCRIPTION
Second round for CFP: http://droidcon.de/en/news/call-papers-enters-second-round