### PR TITLE
Added missing quotes to the event name

### DIFF
--- a/_conferences/devfest-baltics-2017.md
+++ b/_conferences/devfest-baltics-2017.md
@@ -1,5 +1,5 @@
-﻿---
-name: GDG DevFest
+---
+name: "GDG DevFest"
 website: https://devfest.gdg.lv/
 location: Riga, Latvia
 


### PR DESCRIPTION
DevFest Riga isn't appearing on the site. I guess that's the reason.