### PR TITLE
Add support for building on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+rvm:
+- 2.3.3
+
+# Build all branches, *including* gh-pages:
+branches:
+  only:
+  - gh-pages
+  - /.*/
+
+script: bundler exec jekyll build
+
+# route build to the container-based infrastructure for a faster build
+sudo: false


### PR DESCRIPTION
The `branches` thing seems to be necessary for Travis CI to build pull requests against the `gh-pages` branch.

Closes #265 