### PR TITLE
Remove BOMs

### DIFF
--- a/_conferences/andevcon_2016.md
+++ b/_conferences/andevcon_2016.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: AnDevCon
 website: http://www.andevcon.com/
 location: San Francisco, US

--- a/_conferences/devfest-dusseldorf-2017.md
+++ b/_conferences/devfest-dusseldorf-2017.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: GDG DevFest
 website: https://duesseldorf.devfest.de/
 location: Düsseldorf, Germany

--- a/_conferences/devfest-maceio-2017.md
+++ b/_conferences/devfest-maceio-2017.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: GDG DevFest
 website: https://devfest.gdgmaceio.org/
 location: Maceió, AL, Brazil

--- a/_conferences/devfest-switzerland-2017.md
+++ b/_conferences/devfest-switzerland-2017.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: "GDG DevFest"
 website: http://devfest.ch
 location: Fribourg, Switzerland

--- a/_conferences/gdd-europe-2017.md
+++ b/_conferences/gdd-europe-2017.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: GDD Europe
 website: https://developers.google.com/events/gdd-europe/
 location: Krakow, Poland

--- a/_conferences/gdg-heraklion-2017.md
+++ b/_conferences/gdg-heraklion-2017.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: GDG Heraklion
 website: http://heraklion.googledevelopers.gr/
 location: Heraklion, Crete, Greece

--- a/_conferences/united-dev-conf-2017.md
+++ b/_conferences/united-dev-conf-2017.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: United Dev Conf
 website: http://unitedconf.com/
 location: Minsk, Belarus


### PR DESCRIPTION
Files with Byte Order Mark (BOM) are ignored by Jekyll. See https://github.com/jekyll/jekyll/issues/2853