### PR TITLE
updated droidcon boston c4p end

### DIFF
--- a/_conferences/droidcon-boston-2018.md
+++ b/_conferences/droidcon-boston-2018.md
@@ -7,6 +7,6 @@ date_start: 2018-03-26
 date_end:   2018-03-27
 
 cfp_start: 2017-12-11
-cfp_end: 2018-03-01
+cfp_end: 2018-01-14
 cfp_site: https://docs.google.com/forms/d/e/1FAIpQLSdf_oOK9YEEEpGmnORDGob3kOChP1Ebpy1LXdfQbDTrFjHdAA/viewform
 ---


### PR DESCRIPTION
Updated the Droidcon Boston cfp end date to 14th January mentioned in the form here :
https://docs.google.com/forms/d/e/1FAIpQLSdf_oOK9YEEEpGmnORDGob3kOChP1Ebpy1LXdfQbDTrFjHdAA/viewform