### PR TITLE
Display past events as gray.

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ var today = dateTimestamp();
 {% for conference in sorted_conferences %}
   {% assign date_end = (conference.date_end | date: "%s") %}
   {% if today < date_end %}
-  <li>
+  <li id='{{ forloop.index }}'>
     {{ conference.date_start | date: "%Y-%m-%d" }}&nbsp;
     <a class="post-link" href="{{ conference.website }}">{{ conference.name }}</a>
     {% if conference.location %}
@@ -31,6 +31,9 @@ var today = dateTimestamp();
       {% endif %}
       if (today >= dateTimestamp('{{ conference.date_start | date: "%Y-%m-%d" }}') && today <= dateTimestamp('{{ conference.date_end | date: "%Y-%m-%d" }}')) {
         document.write('<span class="label label-danger">Happening Now</span>');
+      }
+      if (today > dateTimestamp('{{ conference.date_end | date: "%Y-%m-%d" }}')) {
+        document.getElementById('{{ forloop.index }}').style.color="gray";
       }
     </script>
   </li>


### PR DESCRIPTION
When the website has not been updated, the conference is still on the index page. This will clarify that the conference is in the past.

Closes #372.