### PR TITLE
Adding Dach Fest

### DIFF
--- a/_conferences/devfest-dach-2018.md
+++ b/_conferences/devfest-dach-2018.md
@@ -1,5 +1,5 @@
 ---
-name: "GDG DACHFest"
+name: "GDG DACH DevFest"
 website: https://twitter.com/dachfest
 location: Munich, Germany
 

--- a/_conferences/devfest-dach-2018.md
+++ b/_conferences/devfest-dach-2018.md
@@ -1,0 +1,8 @@
+---
+name: "GDG DACHFest"
+website: https://twitter.com/dachfest
+location: Munich, Germany
+
+date_start: 2018-11-10
+date_end:   2018-11-11
+---


### PR DESCRIPTION
DACH == Deutschland Austria Switzerland (CH).
This is going to be the first devfest of all the GDG communities in the german speaking countries 