### PR TITLE
AndroidTO 2018

### DIFF
--- a/_conferences/androidto-2018.md
+++ b/_conferences/androidto-2018.md
@@ -1,0 +1,12 @@
+---
+name: "AndroidTO"
+website: http://androidto.com/
+location: Toronto, Canada
+
+date_start: 2018-11-06
+date_end:   2018-11-06
+
+cfp_start:  2018-07-13
+cfp_end:    2018-09-01
+cfp_site:   https://docs.google.com/forms/d/e/1FAIpQLSc3cfxlsKucSFSYpOXD0KxufP0cZNMItwuDGy0O4w7T5tbYoQ/viewform
+---


### PR DESCRIPTION
http://androidto.com/ was updated recently with details about the 2018 event.