### PR TITLE
DevFest Warsaw 2018: cfp_end corrected

### DIFF
--- a/_conferences/devfest-warsaw-2018.md
+++ b/_conferences/devfest-warsaw-2018.md
@@ -7,6 +7,6 @@ date_start: 2018-12-01
 date_end:   2018-12-02
 
 cfp_start: 2018-10-23
-cfp_end:   2018-12-01
+cfp_end:   2018-11-12
 cfp_site: https://docs.google.com/forms/d/e/1FAIpQLSee1vrYSAYOWD6zlnp6uJ7btvzFrJdysKSyEigCywAPODSEeA/viewform
 ---


### PR DESCRIPTION
The end date for call for papers was added on the page. 