### PR TITLE
Add cfp info for droidcon-it-2019

### DIFF
--- a/_conferences/droidcon-it-2019.md
+++ b/_conferences/droidcon-it-2019.md
@@ -5,5 +5,7 @@ location: Turin, IT
 
 date_start: 2019-04-04
 date_end:   2019-04-05
-
+cfp_start: 2018-12-03
+cfp_end: 2019-01-10
+cfp_site: https://www.syx.it/cfp/en/droidcon/droidcon-turin-2019
 ---


### PR DESCRIPTION
I noticed that Droidcon Italy 2019 was missing the info about the call for paper, so I added it :)