### PR TITLE
Extending DevFest Pisa CFP deadline

### DIFF
--- a/_conferences/devfest-pisa-2019.md
+++ b/_conferences/devfest-pisa-2019.md
@@ -7,6 +7,6 @@ date_start: 2019-04-13
 date_end:   2019-04-13
 
 cfp_start: 2018-12-27
-cfp_end:   2019-01-31
+cfp_end:   2019-02-05
 cfp_site:  https://docs.google.com/forms/d/e/1FAIpQLSdgEKpaxBBCCez1B79X4U4m0iCZDAygigEPbqu_guDCxQpnHA/viewform
 ---


### PR DESCRIPTION
We just extended the deadline of our CFP:
https://devfest.gdgpisa.it/blog/posts/5-more-days/
