### PR TITLE
Fix start date of Droicon Greece

### DIFF
--- a/_conferences/droidcon-greece-2019.md
+++ b/_conferences/droidcon-greece-2019.md
@@ -3,7 +3,7 @@ name: "Droidcon"
 website: https://droidcon.gr
 location: Heraklion, Crete, Greece
 
-date_start: 2010-09-24
+date_start: 2019-09-24
 date_end:   2019-09-25
 
 cfp_start: 2019-05-28


### PR DESCRIPTION
Looks like I had a typo and added 2010 as the year of the start date for Droidcon Greece. This fixes it. Sorry for the hassle!