### PR TITLE
Add GDG Devfest Istanbul 2019

### DIFF
--- a/_conferences/devfest-istanbul-2019.md
+++ b/_conferences/devfest-istanbul-2019.md
@@ -7,6 +7,6 @@ date_start: 2019-11-24
 date_end:   2019-11-24
 
 cfp_start: 2019-09-02
-cfp_end:   2019-11-24
+cfp_end:   2019-10-24
 cfp_site: https://t.co/NbBf19Krz8?amp=1
 ---

--- a/_conferences/devfest-istanbul-2019.md
+++ b/_conferences/devfest-istanbul-2019.md
@@ -1,0 +1,12 @@
+---
+name: "GDG DevFest"
+website: https://devfest.istanbul/
+location: Istanbul, Turkey
+
+date_start: 2019-11-24
+date_end:   2019-11-24
+
+cfp_start: 2019-09-02
+cfp_end:   2019-11-24
+cfp_site: https://t.co/NbBf19Krz8?amp=1
+---


### PR DESCRIPTION
Istanbul Devfest is happening on 24 Nov 2019.

For reference : https://twitter.com/GDGIstanbul/status/1168554340820426754