### PR TITLE
Add Droidcon Lisbon 2020

### DIFF
--- a/_conferences/droidcon-lisbon-2020.md
+++ b/_conferences/droidcon-lisbon-2020.md
@@ -1,0 +1,8 @@
+---
+name: "Droidcon"
+website: https://www.eventbrite.com/e/droidcon-lisbon-2020-tickets-72244867343
+location: Lisbon, Portugal
+
+date_start: 2020-09-07
+date_end:   2020-09-08
+---


### PR DESCRIPTION
Ideally we should link the official website: https://www.lisbon.droidcon.com/

Looks like that website is still showing the dates for DC Lisbon 2019. I've added the link to the Eventbrite tickets page with updated dates. We can then change it afterwards.