### PR TITLE
Android Makers Paris 2020

### DIFF
--- a/_conferences/androidmakers-france-2020.md
+++ b/_conferences/androidmakers-france-2020.md
@@ -1,0 +1,8 @@
+---
+name: "Android Makers"
+website: https://androidmakers.fr/
+location: Paris, France
+
+date_start: 2020-04-20
+date_end:   2020-04-21
+---


### PR DESCRIPTION
The website hasn't been updated yet for the 2020 edition. But the ticket sales page contains the dates for 2020.