### PR TITLE
Extend DevFest Pisa CFP deadline

### DIFF
--- a/_conferences/devfest-pisa-2020.md
+++ b/_conferences/devfest-pisa-2020.md
@@ -7,6 +7,6 @@ date_start: 2020-04-18
 date_end:   2020-04-19
 
 cfp_start: 2020-01-15
-cfp_end:   2020-02-15
+cfp_end:   2020-02-17
 cfp_site:  https://sessionize.com/devfest-pisa-2020
 ---


### PR DESCRIPTION
We've moved our deadline to Feb the 17th: https://sessionize.com/devfest-pisa-2020