### PR TITLE
Fix GDG DevFest Budapest 2020 URL

### DIFF
--- a/_conferences/devfest-budapest-2020.md
+++ b/_conferences/devfest-budapest-2020.md
@@ -1,6 +1,6 @@
 ---
 name: "GDG DevFest"
-website: devfest.hu
+website: https://devfest.hu
 location: Budapest, Hungary
 
 date_start: 2020-03-20


### PR DESCRIPTION
Add missing https prefix so link works correctly.