### PR TITLE
Add CFP for Droidcon NYC

### DIFF
--- a/_conferences/droidcon-nyc-2020.md
+++ b/_conferences/droidcon-nyc-2020.md
@@ -5,4 +5,8 @@ location: New York City, NY, USA
 
 date_start: 2020-08-31
 date_end:   2020-09-01
+
+cfp_start:  2020-03-01
+cfp_end:    2020-06-30
+cfp_site:   https://sessionize.com/droidcon-nyc-2020/
 ---


### PR DESCRIPTION
The call for paper for Droidcon New York 2020 has started with the beginning of March.