### PR TITLE
Added support for conference status label

### DIFF
--- a/_conferences/chicago-roboto-2020.md
+++ b/_conferences/chicago-roboto-2020.md
@@ -3,8 +3,8 @@ name: "Chicago Roboto"
 website: http://chicagoroboto.com/
 location: Chicago, IL, USA
 
-date_start: 2020-04-13
-date_end:   2020-04-14
+date_start: 2020-09-28
+date_end:   2020-09-29
 
 cfp_start: 2019-10-30
 cfp_end:   2020-01-04

--- a/_conferences/codemobile-2020.md
+++ b/_conferences/codemobile-2020.md
@@ -2,6 +2,7 @@
 name: "CodeMobile"
 website: http://www.codemobile.co.uk/
 location: London, UK
+status: Cancelled
 
 date_start: 2020-04-28
 date_end:   2020-04-29

--- a/_conferences/facebook-f8-2020.md
+++ b/_conferences/facebook-f8-2020.md
@@ -2,6 +2,7 @@
 name: "Facebook F8"
 website: https://f8.com/
 location: San Jose, CA, USA
+status: Cancelled (online only)
 
 date_start: 2020-05-05
 date_end:   2020-05-06

--- a/_conferences/google-io-2020.md
+++ b/_conferences/google-io-2020.md
@@ -1,0 +1,9 @@
+---
+name: "Google I/O"
+website: https://events.google.com/io/
+location: Mountain View, CA, USA
+status: Cancelled (online only)
+
+date_start: 2020-05-12
+date_end:   2020-05-14
+---

--- a/index.html
+++ b/index.html
@@ -26,11 +26,14 @@ var today = dateTimestamp();
     <script>
       {% if conference.cfp_start %}
       if (today >= dateTimestamp('{{ conference.cfp_start | date: "%Y-%m-%d" }}') && today <= dateTimestamp('{{ conference.cfp_end | date: "%Y-%m-%d" }}')) {
-        document.write('<a href="{% if conference.cfp_site %}{{ conference.cfp_site }}{% else %}{{ conference.website }}{% endif %}"><span class="label label-success">Call For Papers until {{ conference.cfp_end | date: "%Y-%m-%d" }}</span></a>');
+        document.write('<a href="{% if conference.cfp_site %}{{ conference.cfp_site }}{% else %}{{ conference.website }}{% endif %}"><span class="label label-info">Call For Papers until {{ conference.cfp_end | date: "%Y-%m-%d" }}</span></a>');
       }
       {% endif %}
+      {% if conference.status %}
+        document.write('<span class="label label-danger">{{ conference.status }}</span>');
+      {% endif %}
       if (today >= dateTimestamp('{{ conference.date_start | date: "%Y-%m-%d" }}') && today <= dateTimestamp('{{ conference.date_end | date: "%Y-%m-%d" }}')) {
-        document.write('<span class="label label-danger">Happening Now</span>');
+        document.write('<span class="label label-success">Happening Now</span>');
       }
       if (today > dateTimestamp('{{ conference.date_end | date: "%Y-%m-%d" }}')) {
         document.getElementById('{{ forloop.index }}').style.color="gray";


### PR DESCRIPTION
I've added a `status` field to conferences so we can mark cancellations and keep the conference site up to date (especially with the recent cancellations).

I've also updated the following affected conferences:
* Chicago Roboto 2020
* Codemobile UK 2020
* F8
* Google I/O 2020 (was missing)

Here a preview:
<img width="1310" alt="Screenshot 2020-03-03 at 22 12 41" src="https://user-images.githubusercontent.com/3001957/75820328-72c4c180-5d9c-11ea-8651-24e28c87b278.png">
