### PR TITLE
Cancelling KotlinConf 2020

### DIFF
--- a/_conferences/kotlin-conf-2020.md
+++ b/_conferences/kotlin-conf-2020.md
@@ -2,11 +2,8 @@
 name: "KotlinConf"
 website: https://kotlinconf.com/
 location: Montreal, Canada
+status: Cancelled
 
 date_start: 2020-09-09
 date_end:   2020-09-11
-
-cfp_start:  2020-02-05
-cfp_end:    2020-03-31
-cfp_site:   https://sessionize.com/kotlinconf/
 ---


### PR DESCRIPTION
Source: https://kotlinconf.com/
I've also removed the CFP dates so it won't show up the badge