### PR TITLE
Update to Conference for Kotliners 2020

### DIFF
--- a/_conferences/conference-for-kotliners-2020.md
+++ b/_conferences/conference-for-kotliners-2020.md
@@ -1,7 +1,8 @@
 ---
 name: "Conference for Kotliners"
-website: https://www.conferenceforkotliners.com/
+website: https://kotliners.com/conference
 location: Budapest, Hungary
+status: Cancelled (online only)
 
 date_start: 2020-06-05
 date_end:   2020-06-05


### PR DESCRIPTION
- Updated their website URL
- Set their status to `Cancelled (online only)` as they moved to a fully digital agenda given the circumstances

See: https://kotliners.com/conference