### PR TITLE
Don't specify minor Ruby version in GitHub workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.5
+        ruby-version: '2.6'
     - name: Build with jekyll
       run: |
         gem install bundler


### PR DESCRIPTION
Apparently 2.6.5 is no longer available: https://github.com/AndroidStudyGroup/conferences/pull/623/checks?check_run_id=596665951#step:5:4