### PR TITLE
Adapting the website to better support online events

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The contents of the file should use the following template:
 name: "Droidcon"
 website: http://uk.droidcon.com/2015/
 location: London, UK
+status: Cancelled/Postponed # Optional, will show up in red if provided
+online: true                # Optional, for online-only events.
 
 date_start: 2015-10-29
 date_end:   2015-10-30
@@ -30,6 +32,11 @@ cfp_site: http://uk.droidcon.com/2015/lineup-2015/ # Optional, will default to w
 
 *Note: Do not include the location of the conference in the name. The above conference is often referred to as "Droidcon London", but we will always render the location with the name so it is redundant.*
 
+### Online-only events
+
+For online only events please set `online: true` in the template. They will show up in the _Upcoming_ page as well as in the [Online-only](http://androidstudygroup.github.io/conferences/online.html) page.
+
+Please use the `status:` field only for cancellation or postponement as it will show up in red in the website.
 
 Running locally
 ---------------

--- a/_conferences/addc-2020.md
+++ b/_conferences/addc-2020.md
@@ -3,10 +3,6 @@ name: "ADDC"
 website: https://addconf.com/
 location: Barcelona, Spain
 
-date_start: 2020-06-24
-date_end:   2020-06-26
-
-cfp_start: 2020-01-17
-cfp_end:   2020-02-15
-cfp_site:  https://addconf.typeform.com/to/UYLfhu
+date_start: 2021-06-23
+date_end:   2021-06-25
 ---

--- a/_conferences/addc-2021.md
+++ b/_conferences/addc-2021.md
@@ -1,0 +1,12 @@
+---
+name: "ADDC"
+website: https://addconf.com/
+location: Barcelona, Spain
+
+date_start: 2020-06-24
+date_end:   2020-06-26
+
+cfp_start: 2020-01-17
+cfp_end:   2020-02-15
+cfp_site:  https://addconf.typeform.com/to/UYLfhu
+---

--- a/_conferences/android-security-symposium-2020.md
+++ b/_conferences/android-security-symposium-2020.md
@@ -2,7 +2,7 @@
 name: "Android Security Symposium"
 website: https://android.ins.jku.at/symposium/
 location: Linz, Austria
-status: Online only
+online: true
 
 date_start: 2020-07-06
 date_end:   2020-07-07

--- a/_conferences/conference-for-kotliners-2020.md
+++ b/_conferences/conference-for-kotliners-2020.md
@@ -2,7 +2,7 @@
 name: "Conference for Kotliners"
 website: https://kotliners.com/conference
 location: Budapest, Hungary
-status: Cancelled (online only)
+online: true
 
 date_start: 2020-06-05
 date_end:   2020-06-05

--- a/_conferences/devoxx-fr-2020.md
+++ b/_conferences/devoxx-fr-2020.md
@@ -2,6 +2,7 @@
 name: "Devoxx"
 website: http://devoxx.fr/
 location: Paris, France
+status: Canceled
 
 date_start: 2020-07-01
 date_end:   2020-07-03

--- a/_conferences/devoxx-pl-2020.md
+++ b/_conferences/devoxx-pl-2020.md
@@ -3,6 +3,6 @@ name: "Devoxx"
 website: http://devoxx.pl/
 location: Krakow, Poland
 
-date_start: 2020-06-17
-date_end:   2020-06-19
+date_start: 2020-10-28
+date_end:   2020-10-30
 ---

--- a/_conferences/droidcon-nyc-2020.md
+++ b/_conferences/droidcon-nyc-2020.md
@@ -3,10 +3,10 @@ name: "Droidcon"
 website: https://www.nyc.droidcon.com/
 location: New York City, NY, USA
 
-date_start: 2020-08-31
-date_end:   2020-09-01
+date_start: 2020-11-17
+date_end:   2020-11-18
 
 cfp_start:  2020-03-01
-cfp_end:    2020-06-30
+cfp_end:    2020-08-30
 cfp_site:   https://sessionize.com/droidcon-nyc-2020/
 ---

--- a/_conferences/facebook-f8-2020.md
+++ b/_conferences/facebook-f8-2020.md
@@ -2,7 +2,7 @@
 name: "Facebook F8"
 website: https://f8.com/
 location: San Jose, CA, USA
-status: Cancelled (online only)
+status: Canceled
 
 date_start: 2020-05-05
 date_end:   2020-05-06

--- a/_conferences/goto-chicago-2020.md
+++ b/_conferences/goto-chicago-2020.md
@@ -2,6 +2,7 @@
 name: "GOTO"
 website: http://gotochgo.com
 location: Chicago, IL, USA
+online: true
 
 date_start: 2020-04-27
 date_end:   2020-05-01

--- a/_conferences/mdevcamp-2020.md
+++ b/_conferences/mdevcamp-2020.md
@@ -2,7 +2,7 @@
 name: "mDevCamp"
 website: https://mdevcamp.eu/
 location: Prague, Czech Republic
-status: Online only
+online: true
 
 date_start: 2020-06-10
 date_end:   2020-06-11

--- a/_conferences/mobius-spb-2020.md
+++ b/_conferences/mobius-spb-2020.md
@@ -2,6 +2,7 @@
 name: "Mobius"
 website: https://mobius-piter.ru/en/
 location: Saint Petersburg, Russia
+online: true
 
 date_start: 2020-06-23
 date_end:   2020-06-24

--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@ var today = dateTimestamp();
       {% if conference.status %}
         document.write('<span class="label label-danger">{{ conference.status }}</span>');
       {% endif %}
+      {% if conference.online %}
+        document.write('<span class="label label-primary">Online event</span>');
+      {% endif %}
       if (today >= dateTimestamp('{{ conference.date_start | date: "%Y-%m-%d" }}') && today <= dateTimestamp('{{ conference.date_end | date: "%Y-%m-%d" }}')) {
         document.write('<span class="label label-success">Happening Now</span>');
       }

--- a/online.html
+++ b/online.html
@@ -1,0 +1,35 @@
+---
+layout: default
+title: Online only
+---
+
+<script>
+function dateTimestamp(date = undefined) {
+  var day = (date == undefined) ? new Date() : new Date(date);
+  return day.setHours(0, 0, 0, 0)
+}
+
+var today = dateTimestamp();
+</script>
+<ul class="conference-list list-unstyled">
+{% assign sorted_conferences = (site.conferences | sort: 'date_start') %}
+{% assign today = (site.time | date: "%s" ) %}
+{% for conference in sorted_conferences %}
+  {% assign date_end = (conference.date_end | date: "%s") %}
+  {% if (today < date_end and conference.online) %}
+  <li id='{{ forloop.index }}'>
+    {{ conference.date_start | date: "%Y-%m-%d" }}&nbsp;
+    <a class="post-link" href="{{ conference.website }}">{{ conference.name }}</a>
+    {% if conference.location %}
+    &nbsp;<small>{{ conference.location }}</small>
+    {% endif %}
+    <script>
+      document.write('<span class="label label-primary">Online-only event</span>');
+      {% if conference.status %}
+        document.write('<span class="label label-danger">{{ conference.status }}</span>');
+      {% endif %}
+    </script>
+  </li>
+  {% endif %}
+{% endfor %}
+</ul>


### PR DESCRIPTION
With several conferences going online, we should probably distinguish between Canceled events and Online-only events. I'm introducing an `online` boolean flag that allows to control this.

Moreover there is a new `/online` page that filters only Online-only events.
I've also updated several conferences dates/states. 

Here some screenshots:

![Screenshot 2020-04-25 at 02 14 40](https://user-images.githubusercontent.com/3001957/80266218-0f1f8c00-869b-11ea-8acd-1d7afd513101.png)

Online-only page:

![Screenshot 2020-04-25 at 02 14 43](https://user-images.githubusercontent.com/3001957/80266244-23638900-869b-11ea-8651-0819afeacd8b.png)

