### PR TITLE
Use Bootstrap Tables for Conferences List

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,7 @@
   <body>
     <div class="container">
       <div class="header clearfix">
+        <h3 class="text-muted">Android Conferences</h3>
         <nav>
           <ul class="nav nav-pills pull-right">
             {% assign main_pages = site.pages | where_exp:"node", "node.title != null" %}
@@ -27,7 +28,6 @@
             <li role="presentation"><a href="https://github.com/AndroidStudyGroup/conferences/#adding-a-conference">Add</a></li>
           </ul>
         </nav>
-        <h3 class="text-muted">Android Conferences</h3>
       </div>
 
       {{ content }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,6 @@
   <body>
     <div class="container">
       <div class="header clearfix">
-        <h3 class="text-muted">Android Conferences</h3>
         <nav>
           <ul class="nav nav-pills pull-right">
             {% assign main_pages = site.pages | where_exp:"node", "node.title != null" %}
@@ -28,6 +27,7 @@
             <li role="presentation"><a href="https://github.com/AndroidStudyGroup/conferences/#adding-a-conference">Add</a></li>
           </ul>
         </nav>
+        <h3 class="text-muted">Android Conferences</h3>
       </div>
 
       {{ content }}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -52,3 +52,9 @@ body {
     text-align: right;
   }
 }
+
+@media (min-width: 1024px) {
+  .header {
+    border-bottom: none;
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -1,13 +1,15 @@
 ---
 ---
+
 @charset "utf-8";
 
 @import "layout";
 
 .conference-list {
   margin-bottom: 0;
+  table-layout: fixed;
 
-  li {
+  li, tr {
     padding-top: 5px;
     padding-bottom: 5px;
 
@@ -16,7 +18,41 @@
     }
 
     .label {
-      float: right;
+      margin: 2px 4px;
     }
+  }
+
+  td {
+    white-space: normal !important;
+    word-wrap: normal;
+    vertical-align: middle !important;
+  }
+
+  .date-cell {
+    white-space: nowrap !important;
+  }
+}
+
+@media (min-width: 1024px) {
+
+  td {
+    border-top: 1px solid #ddd !important;
+  }
+
+}
+
+@media (max-width: 1024px) {
+
+  td {
+    border-top: none !important;
+  }
+
+  .label {
+    display: block;
+    white-space: normal;
+  }
+
+  .cfp_end {
+    display: none;
   }
 }

--- a/index.html
+++ b/index.html
@@ -4,45 +4,54 @@ title: Upcoming
 ---
 
 <script>
-function dateTimestamp(date = undefined) {
-  var day = (date == undefined) ? new Date() : new Date(date);
-  return day.setHours(0, 0, 0, 0)
-}
+    function dateTimestamp(date = undefined) {
+        var day = (date == undefined) ? new Date() : new Date(date);
+        return day.setHours(0, 0, 0, 0)
+    }
 
-var today = dateTimestamp();
+    var today = dateTimestamp();
 </script>
-<ul class="conference-list list-unstyled">
-{% assign sorted_conferences = (site.conferences | sort: 'date_start') %}
-{% assign today = (site.time | date: "%s" ) %}
-{% for conference in sorted_conferences %}
-  {% assign date_end = (conference.date_end | date: "%s") %}
-  {% if today < date_end %}
-  <li id='{{ forloop.index }}'>
-    {{ conference.date_start | date: "%Y-%m-%d" }}&nbsp;
-    <a class="post-link" href="{{ conference.website }}">{{ conference.name }}</a>
-    {% if conference.location %}
-    &nbsp;<small>{{ conference.location }}</small>
+<table class="table conference-list">
+    {% assign sorted_conferences = (site.conferences | sort: 'date_start') %}
+    {% assign today = (site.time | date: "%s" ) %}
+    {% for conference in sorted_conferences %}
+    {% assign date_start = (conference.date_start | date: "%s") %}
+    {% assign date_end = (conference.date_end | date: "%s") %}
+    {% if today < date_end %}
+    <tr id='{{ forloop.index }}'>
+        <td class="date-cell">{{ conference.date_start | date: "%Y-%m-%d" }}&nbsp;</td>
+        <td><a class="post-link" href="{{ conference.website }}">{{ conference.name }}</a></td>
+        {% if conference.location %}
+            <td><small>{{ conference.location }}</small></td>
+        {% endif %}
+        <!-- Labels -->
+        <td class="labels-cell">
+            {% if conference.cfp_start %}
+                {% assign cfp_start = (conference.cfp_start | date: "%s") %}
+                {% assign cfp_end = (conference.cfp_end | date: "%s") %}
+                {% if conference.status %}
+                    <span class="label label-danger">{{ conference.status }}</span>
+                {% endif %}
+                {% if conference.online %}
+                    <span class="label label-primary">Online event</span>
+                {% endif %}
+                {% if today >= cfp_start and today <= cfp_end %}
+                    {% assign cfp_link = conference.cfp_site | default: conference.website %}
+                    <a href="{{cfp_link}}">
+                        <span class="label label-info">Call For Papers<span class="cfp_end"> until {{ conference.cfp_end | date: "%Y-%m-%d" }}</span></span>
+                    </a>
+                {% endif %}
+                {% if today >= date_start and today <= date_end %}
+                    <span class="label label-success">Happening Now</span>
+                {% endif %}
+            {% endif %}
+        </td>
+        <script>
+            if (today > dateTimestamp('{{ conference.date_end | date: "%Y-%m-%d" }}')) {
+                document.getElementById('{{ forloop.index }}').style.color = "gray";
+            }
+        </script>
+    </tr>
     {% endif %}
-    <script>
-      {% if conference.cfp_start %}
-      if (today >= dateTimestamp('{{ conference.cfp_start | date: "%Y-%m-%d" }}') && today <= dateTimestamp('{{ conference.cfp_end | date: "%Y-%m-%d" }}')) {
-        document.write('<a href="{% if conference.cfp_site %}{{ conference.cfp_site }}{% else %}{{ conference.website }}{% endif %}"><span class="label label-info">Call For Papers until {{ conference.cfp_end | date: "%Y-%m-%d" }}</span></a>');
-      }
-      {% endif %}
-      {% if conference.status %}
-        document.write('<span class="label label-danger">{{ conference.status }}</span>');
-      {% endif %}
-      {% if conference.online %}
-        document.write('<span class="label label-primary">Online event</span>');
-      {% endif %}
-      if (today >= dateTimestamp('{{ conference.date_start | date: "%Y-%m-%d" }}') && today <= dateTimestamp('{{ conference.date_end | date: "%Y-%m-%d" }}')) {
-        document.write('<span class="label label-success">Happening Now</span>');
-      }
-      if (today > dateTimestamp('{{ conference.date_end | date: "%Y-%m-%d" }}')) {
-        document.getElementById('{{ forloop.index }}').style.color="gray";
-      }
-    </script>
-  </li>
-  {% endif %}
-{% endfor %}
-</ul>
+    {% endfor %}
+</table>

--- a/online.html
+++ b/online.html
@@ -3,14 +3,6 @@ layout: default
 title: Online only
 ---
 
-<script>
-function dateTimestamp(date = undefined) {
-  var day = (date == undefined) ? new Date() : new Date(date);
-  return day.setHours(0, 0, 0, 0)
-}
-
-var today = dateTimestamp();
-</script>
 <table class="table conference-list">
 {% assign sorted_conferences = (site.conferences | sort: 'date_start') %}
 {% assign today = (site.time | date: "%s" ) %}
@@ -23,12 +15,10 @@ var today = dateTimestamp();
     {% if conference.location %}
     <td><small>{{ conference.location }}</small></td>
     {% endif %}
-    <script>
-      document.write('<td><span class="label label-primary">Online-only event</span></td>');
-      {% if conference.status %}
-        document.write('<td><span class="label label-danger">{{ conference.status }}</span></td>');
-      {% endif %}
-    </script>
+    <td><span class="label label-primary">Online-only event</span></td>
+    {% if conference.status %}
+    <td><span class="label label-danger">{{ conference.status }}</span></td>
+    {% endif %}
   </tr>
   {% endif %}
 {% endfor %}

--- a/online.html
+++ b/online.html
@@ -11,25 +11,25 @@ function dateTimestamp(date = undefined) {
 
 var today = dateTimestamp();
 </script>
-<ul class="conference-list list-unstyled">
+<table class="table conference-list">
 {% assign sorted_conferences = (site.conferences | sort: 'date_start') %}
 {% assign today = (site.time | date: "%s" ) %}
 {% for conference in sorted_conferences %}
   {% assign date_end = (conference.date_end | date: "%s") %}
   {% if (today < date_end and conference.online) %}
-  <li id='{{ forloop.index }}'>
-    {{ conference.date_start | date: "%Y-%m-%d" }}&nbsp;
-    <a class="post-link" href="{{ conference.website }}">{{ conference.name }}</a>
+  <tr id='{{ forloop.index }}'>
+    <td>{{ conference.date_start | date: "%Y-%m-%d" }}</td>
+    <td><a class="post-link" href="{{ conference.website }}">{{ conference.name }}</a></td>
     {% if conference.location %}
-    &nbsp;<small>{{ conference.location }}</small>
+    <td><small>{{ conference.location }}</small></td>
     {% endif %}
     <script>
-      document.write('<span class="label label-primary">Online-only event</span>');
+      document.write('<td><span class="label label-primary">Online-only event</span></td>');
       {% if conference.status %}
-        document.write('<span class="label label-danger">{{ conference.status }}</span>');
+        document.write('<td><span class="label label-danger">{{ conference.status }}</span></td>');
       {% endif %}
     </script>
-  </li>
+  </tr>
   {% endif %}
 {% endfor %}
-</ul>
+</table>


### PR DESCRIPTION
Right now, the layout is a bit broken on small screens if the line is too long.
This PR addresses that by switching to a table for the layout.

I have also replaced most of the JS by templating, I hope that's fine in terms of caching.

|Desktop|Mobile|
|----|----|
![Desktop](https://user-images.githubusercontent.com/10628007/80315816-596b4f00-87fa-11ea-9f0e-59ea48bc5cc0.png)|![Mobile](https://user-images.githubusercontent.com/10628007/80315831-66883e00-87fa-11ea-9387-9585c3e2c1c4.png)
![Full-length CFP Labels](https://user-images.githubusercontent.com/10628007/80315876-bb2bb900-87fa-11ea-9b05-96486af10206.png)|![CFP Label being shortened](https://user-images.githubusercontent.com/10628007/80315883-c0890380-87fa-11ea-9676-bedfa8275c9e.png)


Things still to do:

- [ ] Find a nice solution for entries with multiple labels
- [x] Adjust `online.html` and `past.html`
