### PR TITLE
Cancel DC Berlin 2020 and create 2021

### DIFF
--- a/_conferences/droidcon-berlin-2020.md
+++ b/_conferences/droidcon-berlin-2020.md
@@ -2,12 +2,9 @@
 name: "Droidcon"
 website: https://berlin.droidcon.com/
 location: Berlin, Germany
+status: Canceled
 
 date_start: 2020-10-07
 date_end:   2020-10-09
 
-cfp:
-  start:  2020-01-22
-  end:    2020-08-01
-  site:   https://sessionize.com/droidcon-berlin-2020/
 ---

--- a/_conferences/droidcon-berlin-2021.md
+++ b/_conferences/droidcon-berlin-2021.md
@@ -1,0 +1,13 @@
+---
+name: "Droidcon"
+website: https://berlin.droidcon.com/
+location: Berlin, Germany
+
+date_start: 2021-07-07
+date_end:   2021-07-09
+
+cfp:
+  start:  2020-01-06
+  end:    2021-04-30
+  site:   https://sessionize.com/droidcon-berlin-2021/
+---


### PR DESCRIPTION
Sadly seems like DC Berlin 2020 won't happen and has been postponed to 2021: https://www.berlin.droidcon.com/