### PR TITLE
GOTO Berlin 2020 is canceled

### DIFF
--- a/_conferences/goto-berlin-2020.md
+++ b/_conferences/goto-berlin-2020.md
@@ -2,6 +2,7 @@
 name: "GOTO"
 website: http://gotober.com/
 location: Berlin, Germany
+status: Canceled
 
 date_start: 2020-10-26
 date_end:   2020-10-30


### PR DESCRIPTION
I couldn't find an announcement for it. But the GOTO Berlin website contains no date for the conference. There's also no indication it had been converted to an online event.