### PR TITLE
Devoxx Poland 2020 is canceled

### DIFF
--- a/_conferences/devoxx-pl-2020.md
+++ b/_conferences/devoxx-pl-2020.md
@@ -2,6 +2,7 @@
 name: "Devoxx"
 website: http://devoxx.pl/
 location: Krakow, Poland
+status: Canceled
 
 date_start: 2020-10-28
 date_end:   2020-10-30


### PR DESCRIPTION
From the website: 
> Due to covid-19, Devoxx Poland 2020 is cancelled.