### PR TITLE
Øredev 2020 is canceled

### DIFF
--- a/_conferences/oredev-2020.md
+++ b/_conferences/oredev-2020.md
@@ -2,6 +2,7 @@
 name: "Øredev"
 website: http://oredev.org/
 location: Malmö, Sweden
+status: Canceled
 
 date_start: 2020-11-04
 date_end:   2020-11-06


### PR DESCRIPTION
Another conference where organizers seem to have a hard time being explicit about the conference being canceled.

> We can finally reveal our plans... Øredev 2020 will be our first event online! It will be something completely different and not like the usual conference 🙌 we believe it's possible to share knowledge online in a great way, are you excited? 🤩
>
> -- https://twitter.com/oredev/status/1258380576526077953 - May 7, 2020

> The best part of Øredev is the one we co-create with you.
> 
> We're sorry to tell you that we're unable to find a remote solution that would offer us the level of interaction, discussion, connection & attention we think you, the speakers & partners deserve.
> 
> Virtual hugs, Ø-team Medium star
>
> -- https://twitter.com/oredev/status/1302870784696819713 - Sep 7,2020

