### PR TITLE
GOTO Copenhagen 2020 canceled

### DIFF
--- a/_conferences/goto-copenhagen-2020.md
+++ b/_conferences/goto-copenhagen-2020.md
@@ -2,6 +2,7 @@
 name: "GOTO"
 website: http://gotocph.com
 location: Copenhagen, Denmark
+status: Canceled
 
 date_start: 2020-11-09
 date_end:   2020-11-13


### PR DESCRIPTION
GOTO CPH 2020 moved to April 2021