### PR TITLE
GOTO: Amsterdam 2020 is canceled

### DIFF
--- a/_conferences/goto-amsterdam-2021.md
+++ b/_conferences/goto-amsterdam-2021.md
@@ -2,8 +2,7 @@
 name: "GOTO"
 website: http://gotoams.nl
 location: Amsterdam, Netherlands
-status: Canceled
 
-date_start: 2020-12-07
-date_end:   2020-12-10
+date_start: 2021-06-15
+date_end:   2021-06-18
 ---


### PR DESCRIPTION
I've canceled the 2020 instalment, and created the 2021 event: https://gotoams.nl/ 