### PR TITLE
update the dates of Droidcon NYC 2021

### DIFF
--- a/_conferences/droidcon-nyc-2021.md
+++ b/_conferences/droidcon-nyc-2021.md
@@ -3,11 +3,11 @@ name: "Droidcon"
 website: https://www.nyc.droidcon.com/
 location: New York City, NY, USA
 
-date_start: 2021-08-30
-date_end:   2021-08-31
+date_start: 2021-11-10
+date_end:   2021-11-11
 
 cfp:
   start:  2020-06-01
-  end:    2021-05-30
+  end:    2021-09-15
   site:   https://sessionize.com/droidcon-nyc-2021
 ---


### PR DESCRIPTION
Seems like the dates for Droidcon NYC 2021 have changed, as seen in their [C4P page](https://sessionize.com/droidcon-nyc-2021).
This PR should update those dates in our list.