### PR TITLE
Fix dead link for droidcon Berlin 2022

### DIFF
--- a/_conferences/droidcon-berlin-2022.md
+++ b/_conferences/droidcon-berlin-2022.md
@@ -1,6 +1,6 @@
 ---
 name: "Droidcon"
-website: https://pretix.eu/droidconglobal/dcberlin22/
+website: https://www.berlin.droidcon.com/
 location: Berlin, Germany
 
 date_start: 2022-07-06


### PR DESCRIPTION
Fixes dead link and links to droidcon website instead of ticket vendor (like for droidcon NYC, SF)