### PR TITLE
Change name from 'Comcast' to 'Philly'.

### DIFF
--- a/_conferences/philly-mobile-dev-2022.md
+++ b/_conferences/philly-mobile-dev-2022.md
@@ -1,0 +1,13 @@
+---
+name: "Philly Mobile Developer Conference"
+website: https://www.comcastlabsconnect.com/2022-mobile
+location: Philadelphia, PA, USA
+online: true
+
+date_start: 2022-05-05
+date_end:   2022-05-05
+cfp:
+  start: 2022-02-10
+  end: 2011-03-20
+  site: https://www.comcastlabsconnect.com/cfp
+---


### PR DESCRIPTION
Hello @cketti , @cortinico , we agree that having 'Comcast' is the name of the conference isn't so great.. We're changing in to 'Philly'!  Let us know what you think.. Thanks!