### PR TITLE
Fix YAML validation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         sed -ni '/---/{:a;n;/---/b;p;ba}' _tmp/*.yml
 
     - name: Validate conference data files
-      uses: eliezio/action-pykwalify@v0.3
+      uses: cketti/action-pykwalify@v0.3-temp-fix
       with:
         files: _tmp/*.yml
         schema: conference_schema.yml


### PR DESCRIPTION
Use a [patched version of the pykwalify action](https://github.com/cketti/action-pykwalify/tree/v0.3-temp-fix). Hopefully, only until the original action is [fixed](https://github.com/eliezio/action-pykwalify/pull/1).

But since nothing is more permanent than a temporary fix, I used what I hope is a Docker image tag that won't change and pinned the versions of the Python dependencies. See https://github.com/cketti/action-pykwalify/commit/241abce09b3b9adcd20a26f7870fd04b38c6394a