### PR TITLE
Fix pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: bom-check
       uses: arma-actions/bom-check@v1.0
@@ -38,12 +38,10 @@ jobs:
         schema: conference_schema.yml
 
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6'
+        bundler-cache: true
 
     - name: Build with jekyll
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        bundle exec jekyll build
+      run: bundle exec jekyll build


### PR DESCRIPTION
`actions/setup-ruby` is deprecated and was replaced by `ruby/setup-ruby`.