### PR TITLE
Fixed location details for mobileWeek 2023

### DIFF
--- a/_conferences/mobileweek-2023.md
+++ b/_conferences/mobileweek-2023.md
@@ -1,7 +1,7 @@
 ---
 name: "mobileWeek"
 website: https://mobileweek.co/
-location: San Mateo, California, United States
+location: San Mateo, CA, USA
 online: true
 
 date_start: 2023-08-15

--- a/_conferences/mobileweek-2023.md
+++ b/_conferences/mobileweek-2023.md
@@ -1,8 +1,7 @@
 ---
 name: "mobileWeek"
 website: https://mobileweek.co/
-location: San Mateo, CA, USA
-online: true
+location: San Mateo, CA, USA & Online
 
 date_start: 2023-08-15
 date_end:   2023-08-23


### PR DESCRIPTION
- Standardized location acronym for mobileWeek 2023 like the other events: _California, United States_ -> _CA, USA_
- Fixed location detail for hybrid instead of online-only like DroidKaigi 2023