### PR TITLE
droidcon-nyc-2023: extend cfp deadline

### DIFF
--- a/_conferences/droidcon-nyc-2023.md
+++ b/_conferences/droidcon-nyc-2023.md
@@ -8,6 +8,6 @@ date_end:   2023-09-15
 
 cfp:
   start: 2023-04-15
-  end:   2023-06-15
+  end:   2023-07-10
   site:  https://sessionize.com/droidcon-nyc-2023/
 ---


### PR DESCRIPTION
The deadline for the [Droidcon NYC 2023 CFP](https://sessionize.com/droidcon-nyc-2023/) has been extended to July 10.