### PR TITLE
add Google Calendar URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,9 @@ title: Upcoming
   {%- assign date_end = conference.date_end | date: "%s" -%}
   {%- if today < date_end %}
   <li id='{{ forloop.index }}' data-conference-start="{{ conference.date_start | date: "%Y-%m-%d" }}" data-conference-end="{{ conference.date_end | date: "%Y-%m-%d" }}">
-    {{ conference.date_start | date: "%Y-%m-%d" }}&nbsp;
+    <a class="post-link" href='https://www.google.com/calendar/render?action=TEMPLATE&text={{ conference.name | replace: " ", "+" }}&dates={{ conference.date_start | date: "%Y%m%d"}}/{{ conference.date_end | date: "%Y%m%d"}}&details=Conference+website:+{{ conference.website }}&location={{ conference.location | replace: " ", "+"}}&sf=true&output=xml'>
+      {{ conference.date_start | date: "%Y-%m-%d" }}
+    </a>&nbsp;
     <a class="post-link" href="{{ conference.website }}">{{ conference.name }}</a>
     {%- if conference.location %}
     &nbsp;<small>{{ conference.location }}</small>


### PR DESCRIPTION
Fixes #80 

This PR adds a hyperlink to the conference date, which lets users add the conference to their Google Calendar.

This what the page looks like with the new hyperlinks:
<img width="400" alt="Screenshot 2023-06-15 at 16 55 08" src="https://github.com/AndroidStudyGroup/conferences/assets/16766726/bfee4080-d8bc-491d-aa0b-1c8c7cd35069">

Example adding Droidcon London to Calendar:
<img width="400" alt="Screenshot 2023-06-15 at 16 57 45" src="https://github.com/AndroidStudyGroup/conferences/assets/16766726/97dcb464-28f6-4db0-95e2-4fec4d9a5aca">

