### PR TITLE
Cancel plDroid Krakow 2024

### DIFF
--- a/_conferences/pldroid-krakow-2024.md
+++ b/_conferences/pldroid-krakow-2024.md
@@ -2,6 +2,7 @@
 name: "plDroid"
 website: https://pldroid.com
 location: Krakow, Poland
+status: Canceled
 
 date_start: 2024-05-29
 date_end:   2024-05-30


### PR DESCRIPTION
from the website:

> We are sorry to announce that Oskar, the originator and organiser of the PlSwift, PlDroid and NYSwifty conferences, passed away on 17 January.
> 
> This year's conferences are cancelled for the moment. We will try to refund your tickets as soon as possible. We also ask that you do not buy any more tickets.
> 
> On behalf of Oskar, we would like to thank you for your interest and attendance at the editions so far.