### PR TITLE
Update CFP end date for Droidcon NYC 2024

### DIFF
--- a/_conferences/droidcon-nyc-2024.md
+++ b/_conferences/droidcon-nyc-2024.md
@@ -8,6 +8,6 @@ date_end:   2024-09-20
 
 cfp:
   start: 2024-04-05
-  end:   2024-07-05
+  end:   2024-07-12
   site: https://sessionize.com/droidcon-nyc-2024/
 ---


### PR DESCRIPTION
The end date was extended here: https://sessionize.com/droidcon-nyc-2024/