### PR TITLE
Include JSON representation of upcoming and past conferences

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,7 +33,7 @@
       {{ content }}
 
       <footer class="footer">
-        <p><a href="conferences.ics">iCalendar</a> &middot;  <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a> &middot; <a href="https://github.com/AndroidStudyGroup/conferences/">GitHub</a></p>
+        <p><a href="conferences.ics">iCalendar</a> &middot; <a href="upcoming.json">JSON</a> &middot; <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a> &middot; <a href="https://github.com/AndroidStudyGroup/conferences/">GitHub</a></p>
       </footer>
     </div>
   </body>

--- a/past.json
+++ b/past.json
@@ -18,15 +18,15 @@ layout: none
     "online": true,
     {%- endif %}
     "dateStart": "{{ conference.date_start | date: "%Y-%m-%d" }}",
-    "dateEnd": "{{ conference.date_end | date: "%Y-%m-%d" }}",
-    {%- if conference.cfp.start %}
+    "dateEnd": "{{ conference.date_end | date: "%Y-%m-%d" }}"
+    {%- if conference.cfp.start -%},
     "cfp": {
       "start": "{{ conference.cfp.start | date: "%Y-%m-%d" }}",
       "end": "{{ conference.cfp.end | date: "%Y-%m-%d" }}",
       "site": "{% if conference.cfp.site %}{{ conference.cfp.site }}{% else %}{{ conference.website }}{% endif %}"
     }
-    {%- endif -%}
-    }{% unless forloop.last %}, {% endunless %}
+    {%- endif %}
+  }{% unless forloop.last %}, {% endunless %}
   {%- endif -%}
-{%- endfor -%}
+{%- endfor %}
 ]

--- a/past.json
+++ b/past.json
@@ -1,0 +1,32 @@
+---
+layout: none
+---
+[
+{%- assign sorted_conferences = site.conferences | sort: 'date_start' | reverse -%}
+{%- assign today = site.time | date: "%s" -%}
+{%- for conference in sorted_conferences -%}
+  {%- assign date_end = conference.date_end | date: "%s" -%}
+  {%- if today >= date_end %}
+  {
+    "name": "{{ conference.name }}",
+    "website": "{{ conference.website }}",
+    "location": "{{ conference.location }}",
+    {%- if conference.status %}
+    "status": "{{ conference.status }}",
+    {%- endif -%}
+    {%- if conference.online %}
+    "online": true,
+    {%- endif %}
+    "dateStart": "{{ conference.date_start | date: "%Y-%m-%d" }}",
+    "dateEnd": "{{ conference.date_end | date: "%Y-%m-%d" }}",
+    {%- if conference.cfp.start %}
+    "cfp": {
+      "start": "{{ conference.cfp.start | date: "%Y-%m-%d" }}",
+      "end": "{{ conference.cfp.end | date: "%Y-%m-%d" }}",
+      "site": "{% if conference.cfp.site %}{{ conference.cfp.site }}{% else %}{{ conference.website }}{% endif %}"
+    }
+    {%- endif -%}
+    }{% unless forloop.last %}, {% endunless %}
+  {%- endif -%}
+{%- endfor -%}
+]

--- a/upcoming.json
+++ b/upcoming.json
@@ -18,15 +18,15 @@ layout: none
     "online": true,
     {%- endif %}
     "dateStart": "{{ conference.date_start | date: "%Y-%m-%d" }}",
-    "dateEnd": "{{ conference.date_end | date: "%Y-%m-%d" }}",
-    {%- if conference.cfp.start %}
+    "dateEnd": "{{ conference.date_end | date: "%Y-%m-%d" }}"
+    {%- if conference.cfp.start -%},
     "cfp": {
       "start": "{{ conference.cfp.start | date: "%Y-%m-%d" }}",
       "end": "{{ conference.cfp.end | date: "%Y-%m-%d" }}",
       "site": "{% if conference.cfp.site %}{{ conference.cfp.site }}{% else %}{{ conference.website }}{% endif %}"
     }
-    {%- endif -%}
-    }{% unless forloop.last %}, {% endunless %}
+    {%- endif %}
+  }{% unless forloop.last %}, {% endunless %}
   {%- endif -%}
-{%- endfor -%}
+{%- endfor %}
 ]

--- a/upcoming.json
+++ b/upcoming.json
@@ -1,0 +1,32 @@
+---
+layout: none
+---
+[
+{%- assign sorted_conferences = site.conferences | sort: 'date_start' -%}
+{%- assign today = site.time | date: "%s" -%}
+{%- for conference in sorted_conferences -%}
+  {%- assign date_end = conference.date_end | date: "%s" -%}
+  {%- if today < date_end %}
+  {
+    "name": "{{ conference.name }}",
+    "website": "{{ conference.website }}",
+    "location": "{{ conference.location }}",
+    {%- if conference.status %}
+    "status": "{{ conference.status }}",
+    {%- endif -%}
+    {%- if conference.online %}
+    "online": true,
+    {%- endif %}
+    "dateStart": "{{ conference.date_start | date: "%Y-%m-%d" }}",
+    "dateEnd": "{{ conference.date_end | date: "%Y-%m-%d" }}",
+    {%- if conference.cfp.start %}
+    "cfp": {
+      "start": "{{ conference.cfp.start | date: "%Y-%m-%d" }}",
+      "end": "{{ conference.cfp.end | date: "%Y-%m-%d" }}",
+      "site": "{% if conference.cfp.site %}{{ conference.cfp.site }}{% else %}{{ conference.website }}{% endif %}"
+    }
+    {%- endif -%}
+    }{% unless forloop.last %}, {% endunless %}
+  {%- endif -%}
+{%- endfor -%}
+]


### PR DESCRIPTION
Whilst playing with a pet project that would list conferences, I found it would be useful to have this information in JSON format, as the alternative required querying the GitHub API.

Sorry for not accompanying this with a feature request or making an issue first, the implementation turned out to be fairly trivial.

~~I couldn't figure out how to preserve a line break after a closing bracket though.~~