### PR TITLE
Android Worldwide 2024 October was canceled

### DIFF
--- a/_conferences/android-worldwide-october-2024.md
+++ b/_conferences/android-worldwide-october-2024.md
@@ -3,6 +3,7 @@ name: "Android Worldwide"
 website: https://android-worldwide.com/
 location: Global
 online: true
+status: Canceled
 
 date_start: 2024-10-29
 date_end:   2024-10-29


### PR DESCRIPTION
It probably doesn't matter as it should have been held already, but Android Worldwide 2024 October was sadly canceled and no more Android Worldwide will be organized (for the forseeable future), see note at the top of https://sessionize.com/android-worldwide-october-2024/