### PR TITLE
New end date for Kotlinconf cfp

### DIFF
--- a/_conferences/kotlin-conf-2025.md
+++ b/_conferences/kotlin-conf-2025.md
@@ -8,6 +8,6 @@ date_end:   2025-05-23
 
 cfp:
   start: 2024-09-16
-  end:   2024-11-30
+  end:   2024-12-08
   site:  https://sessionize.com/kotlinconf-2025/
 ---


### PR DESCRIPTION
End date for CFP was updated on https://sessionize.com/kotlinconf-2025/