### PR TITLE
Add info about droidcon Abu Dhabi, including CfP

### DIFF
--- a/_conferences/droidcon-abu-dhabi-2025.md
+++ b/_conferences/droidcon-abu-dhabi-2025.md
@@ -1,0 +1,13 @@
+---
+name: "Droidcon"
+website: https://www.mobiledevelopersweek.com/
+location: Abu Dhabi, United Arab Emirates
+
+date_start: 2025-12-13
+date_end:   2025-12-15
+
+cfp:
+  start: 2025-07-24
+  end:   2025-10-18
+  site:  https://sessionize.com/mobile-developers-week-abu-dhabi-2025
+---


### PR DESCRIPTION
We can debate whether it should be called Mobile Developers Week (which is the "umbrella" event) or droidcon Abu Dhabi (which IMHO the more relevant to this group)... I don't have a too strong of an opinion, but leaning towards the latter, that's why I submitted like this, but I'm okay if we want to change it!