### PR TITLE
Add droidcon London 2026

### DIFF
--- a/_conferences/droidcon-london-2026.md
+++ b/_conferences/droidcon-london-2026.md
@@ -1,0 +1,8 @@
+---
+name: "Droidcon"
+website: https://london.droidcon.com/
+location: London, UK
+
+date_start: 2026-12-10
+date_end:   2026-12-11
+---


### PR DESCRIPTION
Dates based on the tickets page: https://tickets.droidcon.com/dcldn26/