### PR TITLE
Added Droidcon Orlando 2026

### DIFF
--- a/_conferences/droidcon-orlando-2026.md
+++ b/_conferences/droidcon-orlando-2026.md
@@ -1,0 +1,13 @@
+---
+name: "Droidcon"
+website: https://usa.droidcon.com/
+location: OCCC, Orlando, Florida, USA
+
+date_start: 2026-07-16
+date_end:   2026-07-17
+
+cfp:
+  start: 2026-02-13
+  end:   2026-04-30
+  site: https://sessionize.com/droidcon-orlando-2026/
+---


### PR DESCRIPTION
CFP: https://sessionize.com/droidcon-orlando-2026/
Site: https://usa.droidcon.com/