### PR TITLE
Add DroidKaigi 2026    

### DIFF
--- a/_conferences/droidkaigi-2026.md
+++ b/_conferences/droidkaigi-2026.md
@@ -1,0 +1,13 @@
+---
+name: "DroidKaigi"
+website: https://2026.droidkaigi.jp/en/
+location: Tokyo, Japan
+
+date_start: 2026-09-01
+date_end:   2026-09-03
+
+cfp:
+  start: 2026-04-16
+  end:   2026-05-17
+  site:  https://sessionize.com/droidkaigi2026/
+---


### PR DESCRIPTION
Adds DroidKaigi 2026.                                                                                                                                      
                                                                                                                                                             
  - Date: September 1–3, 2026                                                                                                                                
  - Location: Tokyo, Japan                                                                                                                                   
  - Website: https://2026.droidkaigi.jp/en/                                                                                                                  
  - CFP: April 16 – May 17, 2026 (https://sessionize.com/droidkaigi2026/) 