### PR TITLE
Add droidcon Lisbon 2026

### DIFF
--- a/_conferences/droidcon-lisbon-2026.md
+++ b/_conferences/droidcon-lisbon-2026.md
@@ -1,0 +1,13 @@
+---
+name: "Droidcon"
+website: https://www.lisbon.droidcon.com/
+location: Lisbon, Portugal
+
+date_start: 2026-10-20
+date_end:   2026-10-21
+
+cfp:
+  start: 2026-06-01
+  end:   2026-07-31
+  site: https://sessionize.com/droidcon-lisbon-2026/
+---


### PR DESCRIPTION
Yay, droidcon Lisbon is back!